### PR TITLE
Add failure message when negate to have table row matcher

### DIFF
--- a/lib/rspec_tapas/matchers/have_table_row.rb
+++ b/lib/rspec_tapas/matchers/have_table_row.rb
@@ -25,6 +25,10 @@ module RSpecTapas
         @failure_message
       end
 
+      failure_message_when_negated do |_actual|
+        "Expected not to find table row #{expected} but found"
+      end
+
       private
 
       def with_delay

--- a/spec/rspec_tapas/matchers/have_table_row_spec.rb
+++ b/spec/rspec_tapas/matchers/have_table_row_spec.rb
@@ -19,6 +19,10 @@ describe 'have_table_row matcher' do
         expect(page).to have_table_row(0 => 'John', 1 => 27)
         expect(page).to have_table_row('John', 27)
         expect(page).to have_table_row(have_content('oh'), 27)
+
+        expect do
+          expect(page).not_to have_table_row('Name' => 'John', 'Age' => 27)
+        end.to fail_with('Expected not to find table row {"Name"=>"John", "Age"=>27} but found')
       end
     end
 


### PR DESCRIPTION
After upgrading Rspec I received info that have_table_row should have a message when negated.

<img width="815" alt="Screenshot 2025-01-30 at 09 10 50" src="https://github.com/user-attachments/assets/8f818849-691e-4796-986c-ab65e1b47a15" />
